### PR TITLE
New Resource and DataSource: `Settings`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+## Prerequisites
+
+Please Check that your issue isn't already filed: [Open Issues](https://github.com/brittandeyoung/terraform-provider-awsteam/issues)
+
+## Description
+
+<!-- Description of the issue -->
+
+## Configuration and Steps used to Reproduce
+
+**Expected behavior:**
+
+<!-- What you expect to happen -->
+
+**Actual behavior:**
+
+<!-- What actually happens -->
+
+**Reproduces how often:**
+
+<!-- What percentage of the time does it reproduce? -->
+
+### Provider Version
+
+
+### Additional Information
+
+<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+## Summary
+
+<!-- explanation of the feature being requested. -->
+
+## Motivation
+
+<!-- Why are we doing this? What use cases does it support? What is the expected outcome? -->
+
+## Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,9 @@ on:
   pull_request:
     paths-ignore:
       - 'README.md'
-  push:
-    paths-ignore:
-      - 'README.md'
+  # push:
+  #   paths-ignore:
+  #     - 'README.md'
 
 # Testing only needs permissions to read the repository contents.
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,3 +61,18 @@ jobs:
       - run: go mod download
       - run: go test -v -cover ./...
         timeout-minutes: 10
+
+  golangci-lint:
+    name: golangci-lint
+    runs-on: [custom, linux, large]
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        with:
+          version: "1.55.2"
+          args: --config .golangci.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
 
   golangci-lint:
     name: golangci-lint
-    runs-on: [custom, linux, large]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,5 +74,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: "1.55.2"
+          version: "v1.55.2"
           args: --config .golangci.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,34 +48,16 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
 
-  # Run acceptance tests in a matrix with Terraform CLI versions
   test:
-    name: Terraform Provider Acceptance Tests
+    name: Terraform Provider Unit Tests
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
-          - '1.3.*'
-          - '1.4.*'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: 'go.mod'
           cache: true
-      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
       - run: go mod download
-      - env:
-          TF_ACC: "1"
-        run: go test -v -cover ./internal/provider/
+      - run: go test -v -cover ./...
         timeout-minutes: 10

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:
-  max-per-linter: 0
   max-same-issues: 0
 
 linters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Changelog](http://keepachangelog.com/).
+
+## Unreleased
+---
+
+### New
+
+### Changes
+
+### Fixes
+
+### Breaks
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ---
 
 ### New
+* DataSource: `settings` [#4](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/4)
+* Resource: `settings` [#4](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/4)
 
 ### Changes
 
 ### Fixes
 
 ### Breaks
-
-
-## 0.1.0 - (2024-01-06)
----
-
-### New
-* Resource: `settings` [#4](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/4)
-* DataSource: `settings` [#4](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ---
 
 ### New
+* Resource: `settings` [#4](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/4)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,23 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Changelog](http://keepachangelog.com/).
 
+
 ## Unreleased
 ---
 
 ### New
-* Resource: `settings` [#4](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/4)
 
 ### Changes
 
 ### Fixes
 
 ### Breaks
+
+
+## 0.1.0 - (2024-01-06)
+---
+
+### New
+* Resource: `settings` [#4](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/4)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,5 +21,4 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### New
 * Resource: `settings` [#4](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/4)
-
-
+* DataSource: `settings` [#4](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/4)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[abuse@ckia.dev](mailto:abuse@ckia.dev).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to terraform-provider-awsteam
+
+First off, thanks for taking the time to contribute!
+
+We welcome any contribution. The easiest way to start would be opening an issue. If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) below).
+
+To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+
+To generate or update documentation, run `make gen`.
+
+In order to run the full suite of Acceptance tests, run `make testacc`.
+
+*Note:* Acceptance tests create real resources.
+
+```shell
+make testacc
+```
+
+## Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0
+- [Go](https://golang.org/doc/install) >= 1.19
+
+## Building The Provider
+
+1. Clone the repository
+1. Enter the repository directory
+1. Build the provider using the Go `install` command:
+
+```shell
+go install
+```
+
+## Adding Dependencies
+
+This provider uses [Go modules](https://github.com/golang/go/wiki/Modules).
+Please see the Go documentation for the most up to date information about using Go modules.
+
+To add a new dependency `github.com/author/dependency` to your Terraform provider:
+
+```shell
+go get github.com/author/dependency
+go mod tidy
+```
+
+Then commit the changes to `go.mod` and `go.sum`.
+
+## Using the provider
+
+See the generated [docs](/docs/index.md)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,5 @@
+TESTARGS                ?= "-run=TestAcc"
+
 default: testacc
 
 gen:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,9 +1,16 @@
+PKG_NAME            ?= internal
 TESTARGS                ?= "-run=TestAcc"
 
 default: testacc
 
 gen:
 	go generate
+
+golangci-lint: ## Lint Go source (via golangci-lint)
+	@echo "==> Checking source code with golangci-lint..."
+	@golangci-lint run \
+		--config .golangci.yml \
+		./$(PKG_NAME)/...
 
 test:
 	go test ./...
@@ -14,5 +21,6 @@ testacc:
 
 .PHONY: 
 	- generate
+	- golangci-lint
 	- testacc
 	- test

--- a/README.md
+++ b/README.md
@@ -1,52 +1,5 @@
-# Terraform Provider AWSTEAM
+# Terraform Provider awsteam
 
-This repository is a Work In Progress provider for the [AWS TEAM](https://github.com/aws-samples/iam-identity-center-team) solution. I am currently waiting on the [feature](https://github.com/aws-samples/iam-identity-center-team/issues/33) which will enable programmatic access to the TEAM api. With the current provider, We are only able to read data from the api and not make any changes.  
+The [AWS TEAM Provider](https://registry.terraform.io/providers/brittandeyoung/awsteam/latest/docs) allows [Terraform](https://terraform.io) to manage [AWS TEAM](https://github.com/aws-samples/iam-identity-center-team) resources.
 
-## Requirements
-
-- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.19
-
-## Building The Provider
-
-1. Clone the repository
-1. Enter the repository directory
-1. Build the provider using the Go `install` command:
-
-```shell
-go install
-```
-
-## Adding Dependencies
-
-This provider uses [Go modules](https://github.com/golang/go/wiki/Modules).
-Please see the Go documentation for the most up to date information about using Go modules.
-
-To add a new dependency `github.com/author/dependency` to your Terraform provider:
-
-```shell
-go get github.com/author/dependency
-go mod tidy
-```
-
-Then commit the changes to `go.mod` and `go.sum`.
-
-## Using the provider
-
-See the generated [docs](/docs/index.md)
-
-## Developing the Provider
-
-We welcome any contribution. The easiest way to start would be opening an issue. If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (see [Requirements](#requirements) above).
-
-To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
-
-To generate or update documentation, run `make gen`.
-
-In order to run the full suite of Acceptance tests, run `make testacc`.
-
-*Note:* Acceptance tests create real resources.
-
-```shell
-make testacc
-```
+- [Contributing guide](CONTRIBUTING.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ provider "awsteam" {
 
 ### Optional
 
-- `client_id` (String) The client id for authenticating to the oauth2 token endpoint.
-- `client_secret` (String) The client secret for authenticating to the oauth2 token endpoint.
-- `graph_endpoint` (String) The graph endpoint for the AWS TEAM deployment.
-- `token_endpoint` (String) The token endpoint for the oath2 authenticator for AWS TEAMS.
+- `client_id` (String) The client id for authenticating to the oauth2 token endpoint. This can also be defined by setting the `AWSTEAM_CLIENT_ID` environment variable.
+- `client_secret` (String) The client secret for authenticating to the oauth2 token endpoint. This can also be defined by setting the `AWSTEAM_CLIENT_SECRET` environment variable.
+- `graph_endpoint` (String) The graph endpoint for the AWS TEAM deployment. This can also be defined by setting the `AWSTEAM_GRAPH_ENDPOINT` environment variable.
+- `token_endpoint` (String) The token endpoint for the oath2 authenticator for AWS TEAMS. This can also be defined by setting the `AWSTEAM_TOKEN_ENDPOINT` environment variable.

--- a/docs/resources/settings.md
+++ b/docs/resources/settings.md
@@ -39,7 +39,7 @@ resource "awsteam_settings" "this" {
 - `ses_source_arn` (String) ARN of a verified SES identity in another AWS account. Must be configured to authorize sending mail from the TEAM account.
 - `ses_source_email` (String) Email address to send notifications from. Must be verified in SES.
 - `slack_notifications_enabled` (Boolean) Enable to send notifications directly to users in Slack via a Slack bot app.
-- `slack_token` (String) Slack OAuth token associated with the installed app.
+- `slack_token` (String, Sensitive) Slack OAuth token associated with the installed app.
 - `sns_notifications_enabled` (Boolean) Send notifications via Amazon SNS. Once enabled, create a subscription to the SNS topic (TeamNotifications-main) in the TEAM account.
 - `ticket_no` (Boolean) Determines if ticket number field is mandatory for elevated access requests
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1,4 +1,4 @@
-package provider
+package acctest
 
 import (
 	"testing"

--- a/internal/provider/acctest.go
+++ b/internal/provider/acctest.go
@@ -1,0 +1,32 @@
+package provider
+
+import (
+	"testing"
+	"time"
+)
+
+// These two functions come form the terraform-provider-aws code
+// RunSerialTests1Level runs test cases in parallel, optionally sleeping between each.
+func RunSerialTests1Level(t *testing.T, testCases map[string]func(t *testing.T), d time.Duration) {
+	t.Helper()
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+			time.Sleep(d)
+		})
+	}
+}
+
+// RunSerialTests2Levels runs test cases in parallel, optionally sleeping between each.
+func RunSerialTests2Levels(t *testing.T, testCases map[string]map[string]func(t *testing.T), d time.Duration) {
+	t.Helper()
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			RunSerialTests1Level(t, m, d)
+		})
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -55,19 +55,19 @@ func (p *AWSTEAMProvider) Schema(ctx context.Context, req provider.SchemaRequest
 
 		Attributes: map[string]schema.Attribute{
 			"client_id": schema.StringAttribute{
-				MarkdownDescription: "The client id for authenticating to the oauth2 token endpoint. This can also be defined by setting the AWSTEAM_CLIENT_ID environment variable.",
+				MarkdownDescription: "The client id for authenticating to the oauth2 token endpoint. This can also be defined by setting the `AWSTEAM_CLIENT_ID` environment variable.",
 				Optional:            true,
 			},
 			"client_secret": schema.StringAttribute{
-				MarkdownDescription: "The client secret for authenticating to the oauth2 token endpoint. This can also be defined by setting the AWSTEAM_CLIENT_SECRET environment variable.",
+				MarkdownDescription: "The client secret for authenticating to the oauth2 token endpoint. This can also be defined by setting the `AWSTEAM_CLIENT_SECRET` environment variable.",
 				Optional:            true,
 			},
 			"graph_endpoint": schema.StringAttribute{
-				MarkdownDescription: "The graph endpoint for the AWS TEAM deployment. This can also be defined by setting the AWSTEAM_GRAPH_ENDPOINT environment variable.",
+				MarkdownDescription: "The graph endpoint for the AWS TEAM deployment. This can also be defined by setting the `AWSTEAM_GRAPH_ENDPOINT` environment variable.",
 				Optional:            true,
 			},
 			"token_endpoint": schema.StringAttribute{
-				MarkdownDescription: "The token endpoint for the oath2 authenticator for AWS TEAMS. This can also be defined by setting the AWSTEAM_TOKEN_ENDPOINT environment variable.",
+				MarkdownDescription: "The token endpoint for the oath2 authenticator for AWS TEAMS. This can also be defined by setting the `AWSTEAM_TOKEN_ENDPOINT` environment variable.",
 				Optional:            true,
 			},
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -55,19 +55,19 @@ func (p *AWSTEAMProvider) Schema(ctx context.Context, req provider.SchemaRequest
 
 		Attributes: map[string]schema.Attribute{
 			"client_id": schema.StringAttribute{
-				MarkdownDescription: "The client id for authenticating to the oauth2 token endpoint.",
+				MarkdownDescription: "The client id for authenticating to the oauth2 token endpoint. This can also be defined by setting the AWSTEAM_CLIENT_ID environment variable.",
 				Optional:            true,
 			},
 			"client_secret": schema.StringAttribute{
-				MarkdownDescription: "The client secret for authenticating to the oauth2 token endpoint.",
+				MarkdownDescription: "The client secret for authenticating to the oauth2 token endpoint. This can also be defined by setting the AWSTEAM_CLIENT_SECRET environment variable.",
 				Optional:            true,
 			},
 			"graph_endpoint": schema.StringAttribute{
-				MarkdownDescription: "The graph endpoint for the AWS TEAM deployment.",
+				MarkdownDescription: "The graph endpoint for the AWS TEAM deployment. This can also be defined by setting the AWSTEAM_GRAPH_ENDPOINT environment variable.",
 				Optional:            true,
 			},
 			"token_endpoint": schema.StringAttribute{
-				MarkdownDescription: "The token endpoint for the oath2 authenticator for AWS TEAMS.",
+				MarkdownDescription: "The token endpoint for the oath2 authenticator for AWS TEAMS. This can also be defined by setting the AWSTEAM_TOKEN_ENDPOINT environment variable.",
 				Optional:            true,
 			},
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -18,6 +18,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
+const (
+	ProviderName = "awsteam"
+)
+
 type AWSTEAMClient struct {
 	Client        *awsteam.Client
 	Config        *awsteam.Config
@@ -25,18 +29,12 @@ type AWSTEAMClient struct {
 	GraphEndpoint string
 }
 
-// Ensure AWSTEAMProvider satisfies various provider interfaces.
 var _ provider.Provider = &AWSTEAMProvider{}
 
-// AWSTEAMProvider defines the provider implementation.
 type AWSTEAMProvider struct {
-	// version is set to the provider version on release, "dev" when the
-	// provider is built and ran locally, and "test" when running acceptance
-	// testing.
 	version string
 }
 
-// AWSTEAMProviderModel describes the provider data model.
 type AWSTEAMProviderModel struct {
 	ClientId      types.String `tfsdk:"client_id"`
 	ClientSecret  types.String `tfsdk:"client_secret"`
@@ -45,7 +43,7 @@ type AWSTEAMProviderModel struct {
 }
 
 func (p *AWSTEAMProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
-	resp.TypeName = "awsteam"
+	resp.TypeName = ProviderName
 	resp.Version = p.version
 }
 
@@ -91,9 +89,6 @@ func (p *AWSTEAMProvider) Configure(ctx context.Context, req provider.ConfigureR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// Configure the AWS TEAM client
-	// First we need to get a token from the oath endpoint
 
 	config := &awsteam.Config{
 		ClientId:      clientId,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -7,39 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// testAccProtoV6ProviderFactories are used to instantiate a provider during
-// acceptance testing. The factory function will be invoked for every Terraform
-// CLI command executed to create a provider server to which the CLI can
-// reattach.
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"awsteam": providerserver.NewProtocol6WithError(New("test")()),
+	ProviderName: providerserver.NewProtocol6WithError(New("test")()),
 }
 
 func testAccPreCheck(t *testing.T) {
-	// You can add code here to run prior to any test case execution, for example assertions
-	// about the appropriate environment variables being set are common to see in a pre-check
-	// function.
-	// 	testAccProviderConfigure.Do(func() {
-	// 		envvar.FailIfAllEmpty(t, []string{envvar.Profile, envvar.AccessKeyId, envvar.ContainerCredentialsFullURI}, "credentials for running acceptance testing")
-
-	// 		if os.Getenv(envvar.AccessKeyId) != "" {
-	// 			envvar.FailIfEmpty(t, envvar.SecretAccessKey, "static credentials value when using "+envvar.AccessKeyId)
-	// 		}
-
-	// 		// Setting the AWS_DEFAULT_REGION environment variable here allows all tests to omit
-	// 		// a provider configuration with a region. This defaults to us-west-2 for provider
-	// 		// developer simplicity and has been in the codebase for a very long time.
-	// 		//
-	// 		// This handling must be preserved until either:
-	// 		//   * AWS_DEFAULT_REGION is required and checked above (should mention us-west-2 default)
-	// 		//   * Region is automatically handled via shared AWS configuration file and still verified
-	// 		region := Region()
-	// 		os.Setenv(envvar.DefaultRegion, region)
-
-	// diags := provider.Configure(ctx, terraformsdk.NewResourceConfigRaw(nil))
-	// if err := sdkdiag.DiagnosticsError(diags); err != nil {
-	// 	t.Fatalf("configuring provider: %s", err)
-	// }
-	//		})
-	//	}
+	// We do not currently have any PreChecks
 }

--- a/internal/provider/settings.go
+++ b/internal/provider/settings.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -94,10 +95,14 @@ func (r *SettingsResource) Schema(ctx context.Context, req resource.SchemaReques
 			"ses_source_arn": schema.StringAttribute{
 				MarkdownDescription: "ARN of a verified SES identity in another AWS account. Must be configured to authorize sending mail from the TEAM account.",
 				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Computed:            true,
 			},
 			"ses_source_email": schema.StringAttribute{
 				MarkdownDescription: "Email address to send notifications from. Must be verified in SES.",
 				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Computed:            true,
 			},
 			"sns_notifications_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Send notifications via Amazon SNS. Once enabled, create a subscription to the SNS topic (TeamNotifications-main) in the TEAM account.",
@@ -114,6 +119,8 @@ func (r *SettingsResource) Schema(ctx context.Context, req resource.SchemaReques
 			"slack_token": schema.StringAttribute{
 				MarkdownDescription: "Slack OAuth token associated with the installed app.",
 				Optional:            true,
+				Default:             stringdefault.StaticString(""),
+				Computed:            true,
 			},
 			"team_admin_group": schema.StringAttribute{
 				MarkdownDescription: "Group of users responsible for managing TEAM administrative configurations",
@@ -367,15 +374,12 @@ func (r *SettingsResource) Delete(ctx context.Context, req resource.DeleteReques
 
 	in := &awsteam.DeleteSettingsInput{}
 
-	out, err := r.client.DeleteSettings(ctx, in)
+	_, err := r.client.DeleteSettings(ctx, in)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read settings, got error: %s", err))
 		return
 	}
-
-	fmt.Println(out)
-
 }
 
 func (r *SettingsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/settings.go
+++ b/internal/provider/settings.go
@@ -29,8 +29,8 @@ type SettingsResource struct {
 	client *awsteam.Client
 }
 
-// SettingsResourceModel describes the data source data model.
-type SettingsResourceModel struct {
+// SettingsModel describes the data source data model.
+type SettingsModel struct {
 	Approval                  types.Bool   `tfsdk:"approval"`
 	Comments                  types.Bool   `tfsdk:"comments"`
 	Id                        types.String `tfsdk:"id"`
@@ -172,7 +172,7 @@ func (r *SettingsResource) Configure(ctx context.Context, req resource.Configure
 }
 
 func (r *SettingsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data SettingsResourceModel
+	var data SettingsModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
@@ -237,7 +237,7 @@ func (r *SettingsResource) Create(ctx context.Context, req resource.CreateReques
 }
 
 func (r *SettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data SettingsResourceModel
+	var data SettingsModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -280,7 +280,7 @@ func (r *SettingsResource) Read(ctx context.Context, req resource.ReadRequest, r
 }
 
 func (r *SettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var config, plan, state SettingsResourceModel
+	var config, plan, state SettingsModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
@@ -364,7 +364,7 @@ func (r *SettingsResource) Update(ctx context.Context, req resource.UpdateReques
 }
 
 func (r *SettingsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data SettingsResourceModel
+	var data SettingsModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 

--- a/internal/provider/settings.go
+++ b/internal/provider/settings.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &SettingsResource{}
 var _ resource.ResourceWithImportState = &SettingsResource{}
 
@@ -24,12 +23,10 @@ func NewSettingsResource() resource.Resource {
 	return &SettingsResource{}
 }
 
-// SettingsResource defines the resource implementation.
 type SettingsResource struct {
 	client *awsteam.Client
 }
 
-// SettingsModel describes the data source data model.
 type SettingsModel struct {
 	Approval                  types.Bool   `tfsdk:"approval"`
 	Comments                  types.Bool   `tfsdk:"comments"`
@@ -239,7 +236,6 @@ func (r *SettingsResource) Create(ctx context.Context, req resource.CreateReques
 func (r *SettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var data SettingsModel
 
-	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/settings.go
+++ b/internal/provider/settings.go
@@ -118,6 +118,7 @@ func (r *SettingsResource) Schema(ctx context.Context, req resource.SchemaReques
 				Optional:            true,
 				Default:             stringdefault.StaticString(""),
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"team_admin_group": schema.StringAttribute{
 				MarkdownDescription: "Group of users responsible for managing TEAM administrative configurations",

--- a/internal/provider/settings_data_source.go
+++ b/internal/provider/settings_data_source.go
@@ -23,27 +23,6 @@ type SettingsDataSource struct {
 	client *awsteam.Client
 }
 
-// SettingsDataSourceModel describes the data source data model.
-type SettingsDataSourceModel struct {
-	Approval                  types.Bool   `tfsdk:"approval"`
-	Comments                  types.Bool   `tfsdk:"comments"`
-	Id                        types.String `tfsdk:"id"`
-	Duration                  types.Int64  `tfsdk:"duration"`
-	Expiry                    types.Int64  `tfsdk:"expiry"`
-	SesNotificationsEnabled   types.Bool   `tfsdk:"ses_notifications_enabled"`
-	SnsNotificationsEnabled   types.Bool   `tfsdk:"sns_notifications_enabled"`
-	SlackNotificationsEnabled types.Bool   `tfsdk:"slack_notifications_enabled"`
-	SesSourceEmail            types.String `tfsdk:"ses_source_email"`
-	SesSourceArn              types.String `tfsdk:"ses_source_arn"`
-	SlackToken                types.String `tfsdk:"slack_token"`
-	TeamAdminGroup            types.String `tfsdk:"team_admin_group"`
-	TeamAuditorGroup          types.String `tfsdk:"team_auditor_group"`
-	TicketNo                  types.Bool   `tfsdk:"ticket_no"`
-	ModifiedBy                types.String `tfsdk:"modified_by"`
-	CreatedAt                 types.String `tfsdk:"created_at"`
-	UpdatedAt                 types.String `tfsdk:"updated_at"`
-}
-
 func (d *SettingsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_settings"
 }
@@ -147,7 +126,7 @@ func (d *SettingsDataSource) Configure(ctx context.Context, req datasource.Confi
 }
 
 func (d *SettingsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data SettingsDataSourceModel
+	var data SettingsModel
 
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)

--- a/internal/provider/settings_data_source.go
+++ b/internal/provider/settings_data_source.go
@@ -11,14 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// Ensure provider defined types fully satisfy framework interfaces.
 var _ datasource.DataSource = &SettingsDataSource{}
 
 func NewSettingsDataSource() datasource.DataSource {
 	return &SettingsDataSource{}
 }
 
-// SettingsDataSource defines the data source implementation.
 type SettingsDataSource struct {
 	client *awsteam.Client
 }
@@ -29,7 +27,6 @@ func (d *SettingsDataSource) Metadata(ctx context.Context, req datasource.Metada
 
 func (d *SettingsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Provides a data source for AWS TEAM Settings",
 
 		Attributes: map[string]schema.Attribute{
@@ -106,7 +103,6 @@ func (d *SettingsDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 }
 
 func (d *SettingsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
 		return
 	}
@@ -128,7 +124,6 @@ func (d *SettingsDataSource) Configure(ctx context.Context, req datasource.Confi
 func (d *SettingsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data SettingsModel
 
-	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/settings_data_source_test.go
+++ b/internal/provider/settings_data_source_test.go
@@ -1,43 +1,57 @@
 package provider
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccSettingsDataSource(t *testing.T) {
-	dataSource := "data.awsteam_settings.test"
+func testAccSettingsDataSource_basic(t *testing.T) {
+	resourceName := "awsteam_settings.test"
+	dataSourceName := "data.awsteam_settings.test"
+	teamAdminGroup := "Team-Admin-Group"
+	teamAuditorGroup := "Team-Auditor-Group"
+	duration := rand.Intn(10)
+	expiry := rand.Intn(10)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSettingsDataSourceConfig,
+				Config: testAccSettingsDataSourceConfig(teamAdminGroup, teamAuditorGroup, duration, expiry),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSource, "id", "settings"),
-					// resource.TestCheckResourceAttrSet(dataSource, "approval"),
-					// resource.TestCheckResourceAttrSet(dataSource, "comments"),
-					// resource.TestCheckResourceAttrSet(dataSource, "max_request_duration"),
-					// resource.TestCheckResourceAttrSet(dataSource, "request_expiry_timeout"),
-					// resource.TestCheckResourceAttrSet(dataSource, "ses_notifications_enabled"),
-					// resource.TestCheckResourceAttrSet(dataSource, "sns_notifications_enabled"),
-					// resource.TestCheckResourceAttrSet(dataSource, "slack_notifications_enabled"),
-					// resource.TestCheckResourceAttrSet(dataSource, "ses_source_email"),
-					// resource.TestCheckResourceAttrSet(dataSource, "ses_source_arn"),
-					// resource.TestCheckResourceAttrSet(dataSource, "slack_token"),
-					// resource.TestCheckResourceAttrSet(dataSource, "team_admin_group"),
-					// resource.TestCheckResourceAttrSet(dataSource, "team_auditor_group"),
-					// resource.TestCheckResourceAttrSet(dataSource, "ticket_no"),
-					// resource.TestCheckResourceAttrSet(dataSource, "modified_by"),
-					// resource.TestCheckResourceAttrSet(dataSource, "created_at"),
-					// resource.TestCheckResourceAttrSet(dataSource, "updated_at"),
+					resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "team_admin_group", dataSourceName, "team_admin_group"),
+					resource.TestCheckResourceAttrPair(resourceName, "team_auditor_group", dataSourceName, "team_auditor_group"),
+					resource.TestCheckResourceAttrPair(resourceName, "approval", dataSourceName, "approval"),
+					resource.TestCheckResourceAttrPair(resourceName, "comments", dataSourceName, "comments"),
+					resource.TestCheckResourceAttrPair(resourceName, "ses_notifications_enabled", dataSourceName, "ses_notifications_enabled"),
+					resource.TestCheckResourceAttrPair(resourceName, "sns_notifications_enabled", dataSourceName, "sns_notifications_enabled"),
+					resource.TestCheckResourceAttrPair(resourceName, "slack_notifications_enabled", dataSourceName, "slack_notifications_enabled"),
+					resource.TestCheckResourceAttrPair(resourceName, "ticket_no", dataSourceName, "ticket_no"),
+					resource.TestCheckResourceAttrPair(resourceName, "created_at", dataSourceName, "created_at"),
+					resource.TestCheckResourceAttrPair(resourceName, "updated_at", dataSourceName, "updated_at"),
 				),
 			},
 		},
 	})
 }
+func testAccSettingsDataSourceConfig(teamAdminGroup string, teamAuditorGroup string, duration int, expiry int) string {
+	return fmt.Sprintf(`
+resource "awsteam_settings" "test" {
+	team_admin_group = %[1]q
+	team_auditor_group = %[2]q
+	duration = %d
+	expiry = %d
+  }
 
-const testAccSettingsDataSourceConfig = `
-data "awsteam_settings" "test" {}
-`
+data "awsteam_settings" "test" {
+	depends_on = [
+		awsteam_settings.test
+	]
+}
+`, teamAdminGroup, teamAuditorGroup, duration, expiry)
+}

--- a/internal/provider/settings_test.go
+++ b/internal/provider/settings_test.go
@@ -3,13 +3,25 @@ package provider
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"testing"
 
+	"github.com/brittandeyoung/terraform-provider-awsteam/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// AWS TEAM Only allows one settings to be defined at a time.
 func TestAccSettings_serial(t *testing.T) {
 	t.Parallel()
+
+	// AWS TEAM only allows settings to be defined once, Running these tests requires the settings to be deleted from the environment before running.
+	// Added an environment variable that will enable us to control when these tests run.
+	// To run these tests set the environment variable like so: export AWSTEAM_RUN_SETTINGS_TESTS="true"
+	key := "AWSTEAM_RUN_SETTINGS_TESTS"
+	vifId := os.Getenv(key)
+	if vifId != "true" {
+		t.Skipf("Skipping Settings Tests, Environment variable %s is not set to true", key)
+	}
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"Resource": {
@@ -20,7 +32,7 @@ func TestAccSettings_serial(t *testing.T) {
 		},
 	}
 
-	RunSerialTests2Levels(t, testCases, 0)
+	acctest.RunSerialTests2Levels(t, testCases, 0)
 }
 
 func testAccSettingsResource_basic(t *testing.T) {

--- a/internal/provider/settings_test.go
+++ b/internal/provider/settings_test.go
@@ -62,23 +62,19 @@ func testAccSettingsResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ticket_no", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
-					// resource.TestCheckResourceAttrSet(resourceName, "modified_by"),
 				),
 			},
-			// ImportState testing
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Update and Read testing
 			{
 				Config: testAccSettingsResourceConfig(teamAdminGroup2, teamAuditorGroup2, duration, expiry),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "team_admin_group", teamAdminGroup2),
 					resource.TestCheckResourceAttr(resourceName, "team_auditor_group", teamAuditorGroup2)),
 			},
-			// Delete testing automatically occurs in TestCase
 		},
 	})
 }

--- a/internal/provider/settings_test.go
+++ b/internal/provider/settings_test.go
@@ -8,7 +8,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccSettingsResource_basic(t *testing.T) {
+func TestAccSettings_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]map[string]func(t *testing.T){
+		"Resource": {
+			"basic": testAccSettingsResource_basic,
+		},
+		"DataSource": {
+			"basic": testAccSettingsDataSource_basic,
+		},
+	}
+
+	RunSerialTests2Levels(t, testCases, 0)
+}
+
+func testAccSettingsResource_basic(t *testing.T) {
 	resourceName := "awsteam_settings.test"
 	teamAdminGroup1 := "Team-Admin-Group"
 	teamAuditorGroup1 := "Team-Auditor-Group"
@@ -27,15 +42,15 @@ func TestAccSettingsResource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "team_admin_group", teamAdminGroup1),
 					resource.TestCheckResourceAttr(resourceName, "team_auditor_group", teamAuditorGroup1),
-					resource.TestCheckResourceAttr(resourceName, "approval", "settings"),
-					resource.TestCheckResourceAttr(resourceName, "comments", "settings"),
-					resource.TestCheckResourceAttr(resourceName, "ses_notifications_enabled", "settings"),
-					resource.TestCheckResourceAttr(resourceName, "sns_notifications_enabled", "settings"),
-					resource.TestCheckResourceAttr(resourceName, "slack_notifications_enabled", "settings"),
-					resource.TestCheckResourceAttr(resourceName, "ticket_no", "settings"),
+					resource.TestCheckResourceAttr(resourceName, "approval", "false"),
+					resource.TestCheckResourceAttr(resourceName, "comments", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ses_notifications_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "sns_notifications_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "slack_notifications_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ticket_no", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "modified_by"),
+					// resource.TestCheckResourceAttrSet(resourceName, "modified_by"),
 				),
 			},
 			// ImportState testing

--- a/internal/sdk/awsteam/config.go
+++ b/internal/sdk/awsteam/config.go
@@ -46,7 +46,7 @@ type Config struct {
 func (config *Config) Build() {
 	// Configure the AWS TEAM client
 	// First we need to get a token from the oath endpoint
-	authPayload := strings.NewReader(fmt.Sprintf(`grant_type=client_credentials&client_id=%s&client_secret=%s`, config.ClientId, config.ClientSecret))
+	authPayload := strings.NewReader(fmt.Sprintf(`grant_type=client_credentials&scope=api%%2Fadmin&client_id=%s&client_secret=%s`, config.ClientId, config.ClientSecret))
 
 	authClient := &http.Client{}
 	authReq, err := http.NewRequest("POST", config.TokenEndpoint, authPayload)


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This pull request implements a new resource and data source for AWS TEAM `settings`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #3 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Running Acceptance Tests
<!--
Output from Acceptance tests to test the new feature or fix.
-->

```
➜ terraform-provider-awsteam (main) ✗ make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?       github.com/brittandeyoung/terraform-provider-awsteam    [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/envvar    [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam       [no test files]
=== RUN   TestAccSettings_serial
=== PAUSE TestAccSettings_serial
=== CONT  TestAccSettings_serial
=== RUN   TestAccSettings_serial/Resource
=== RUN   TestAccSettings_serial/Resource/basic
=== RUN   TestAccSettings_serial/DataSource
=== RUN   TestAccSettings_serial/DataSource/basic
--- PASS: TestAccSettings_serial (12.19s)
    --- PASS: TestAccSettings_serial/Resource (7.15s)
        --- PASS: TestAccSettings_serial/Resource/basic (7.15s)
    --- PASS: TestAccSettings_serial/DataSource (5.04s)
        --- PASS: TestAccSettings_serial/DataSource/basic (5.04s)
PASS
ok      github.com/brittandeyoung/terraform-provider-awsteam/internal/provider  12.629s

...
```