### PR TITLE
fix(issue-23): panic: unsupported protocol scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Changes
 
 ### Fixes
+* Provider: Corrected the provider schema attribute mapping to configuration fields for `client_secret`, `graph_endpoint`, and `token_endpoint` [24](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/24)
+
 
 ### Breaks
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -87,9 +87,9 @@ func (p *AWSTEAMProvider) Configure(ctx context.Context, req provider.ConfigureR
 	}
 
 	clientId := fieldOrEnvVar(data.ClientId, "client_id", envvar.AWSTEAMClientId, resp)
-	clientSecret := fieldOrEnvVar(data.ClientId, "client_secret", envvar.AWSTEAMClientSecret, resp)
-	graphEndpoint := fieldOrEnvVar(data.ClientId, "graph_endpoint", envvar.AWSTEAMGraphEndpoint, resp)
-	TokenEndpoint := fieldOrEnvVar(data.ClientId, "token_endpoint", envvar.AWSTEAMTokenEndpoint, resp)
+	clientSecret := fieldOrEnvVar(data.ClientSecret, "client_secret", envvar.AWSTEAMClientSecret, resp)
+	graphEndpoint := fieldOrEnvVar(data.GraphEndpoint, "graph_endpoint", envvar.AWSTEAMGraphEndpoint, resp)
+	TokenEndpoint := fieldOrEnvVar(data.TokenEndpoint, "token_endpoint", envvar.AWSTEAMTokenEndpoint, resp)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -102,7 +102,7 @@ func (p *AWSTEAMProvider) Configure(ctx context.Context, req provider.ConfigureR
 		TokenEndpoint: TokenEndpoint,
 	}
 
-	config.Build()
+	config.Build(ctx)
 
 	meta := config.NewClient(ctx)
 
@@ -142,7 +142,7 @@ func fieldOrEnvVar(field basetypes.StringValue, fieldName string, envvarName str
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Providing a value for %s is required. This can also be handled by setting the %s environment variable.", fieldName, envvarName))
 		}
 	} else {
-		value = field.String()
+		value = field.ValueString()
 	}
 	return value
 }


### PR DESCRIPTION
### Description
Due to an development error, the provider configuration would only accept values that are provided from environment variables and replace those parameters with the `client_id` instead. This PR fixes this issue. Another oversight was a call to `field.String()` which is to be used for logging and outputs an erronous string value for the configuration such as enclosing the value with double quotes ("). It has been properly replaced with `field.ValueString()` which will not break the configuration and thus fix the parsing error from `net/url` when providing a correct scheme.

### Relations
Closes #23 
