### PR TITLE
Resolve incorect Ids for Eligibilities, Resolve errors when resources deleted outside of state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Breaks
 
 
+## 1.0.1 - (2024-03-05)
+---
+
+### Fixes
+* Resource: `awsteam_eligibility_group` now requires the `group_id` field. This will be used as the resource `id`. [36](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/36)
+* Resource: `awsteam_eligibility_user` now requires the `user_id` field. This will be used as the resource `id`. [36](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/36)
+* Resources: `awsteam_eligibility_group`, `awsteam_eligibility_user`, `awsteam_approvers_account`, `awsteam_approvers_ou`, and `awsteam_settings` Deleting outside of terraform will no longer cause terraform to error.
+
+
 ## 1.0.0 - (2024-02-27)
 ---
 

--- a/docs/resources/eligibility_group.md
+++ b/docs/resources/eligibility_group.md
@@ -44,16 +44,16 @@ resource "awsteam_eligibility_group" "example" {
 
 ### Required
 
+- `accounts` (Attributes Set) A list of AWS accounts the eligibility will apply to. (see [below for nested schema](#nestedatt--accounts))
 - `approval_required` (Boolean) Determines if approval is required for elevated access
 - `duration` (Number) The maximum elevated access request duration in hours.
 - `group_id` (String) Id of the AWS iam identity center group the eligibility policy will be applied to.
 - `group_name` (String) Name of the AWS iam identity center group the eligibility policy will be applied to.
+- `ous` (Attributes Set) A list of AWS OUs the eligibility will apply to. (see [below for nested schema](#nestedatt--ous))
 - `permissions` (Attributes Set) A list of AWS permission sets for the eligibility policy. (see [below for nested schema](#nestedatt--permissions))
 
 ### Optional
 
-- `accounts` (Attributes Set) A list of AWS accounts the eligibility will apply to. (see [below for nested schema](#nestedatt--accounts))
-- `ous` (Attributes Set) A list of AWS OUs the eligibility will apply to. (see [below for nested schema](#nestedatt--ous))
 - `ticket_no` (String) The Change Management system ticket system number.
 
 ### Read-Only
@@ -62,15 +62,6 @@ resource "awsteam_eligibility_group" "example" {
 - `id` (String) The UUID of the eligibility.
 - `modified_by` (String) The user to last modify the item
 - `updated_at` (String) The date and time of the last time the item was updated
-
-<a id="nestedatt--permissions"></a>
-### Nested Schema for `permissions`
-
-Required:
-
-- `permission_arn` (String) The ARN of the permission for the eligibility policy. This needs to match the ARN of the name provided in name.
-- `permission_name` (String) Name of the permission for the eligibility policy. This needs to match the name of the ARN provided in ARN.
-
 
 <a id="nestedatt--accounts"></a>
 ### Nested Schema for `accounts`
@@ -88,6 +79,15 @@ Required:
 
 - `ou_id` (String) Id of the OU the eligibility policy will be applied to. This needs to match the id of the name provided in ou_name.
 - `ou_name` (String) Name of the OU the eligibility policy will be applied to. This needs to match the name of the id provided in ou_id.
+
+
+<a id="nestedatt--permissions"></a>
+### Nested Schema for `permissions`
+
+Required:
+
+- `permission_arn` (String) The ARN of the permission for the eligibility policy. This needs to match the ARN of the name provided in name.
+- `permission_name` (String) Name of the permission for the eligibility policy. This needs to match the name of the ARN provided in ARN.
 
 ## Import
 

--- a/docs/resources/eligibility_group.md
+++ b/docs/resources/eligibility_group.md
@@ -15,6 +15,7 @@ Allows configuration of eligibility policies for an aws iam identity center grou
 ```terraform
 resource "awsteam_eligibility_group" "example" {
   group_name        = "my-group@contoso.com"
+  group_id          = "d78686b5-bb78-471c-8b2f-817e70e3158b"
   approval_required = true
   duration          = 5
   accounts = [
@@ -45,6 +46,7 @@ resource "awsteam_eligibility_group" "example" {
 
 - `approval_required` (Boolean) Determines if approval is required for elevated access
 - `duration` (Number) The maximum elevated access request duration in hours.
+- `group_id` (String) Id of the AWS iam identity center group the eligibility policy will be applied to.
 - `group_name` (String) Name of the AWS iam identity center group the eligibility policy will be applied to.
 - `permissions` (Attributes Set) A list of AWS permission sets for the eligibility policy. (see [below for nested schema](#nestedatt--permissions))
 

--- a/docs/resources/eligibility_user.md
+++ b/docs/resources/eligibility_user.md
@@ -44,16 +44,16 @@ resource "awsteam_eligibility_user" "example" {
 
 ### Required
 
+- `accounts` (Attributes Set) A list of AWS accounts the eligibility will apply to. (see [below for nested schema](#nestedatt--accounts))
 - `approval_required` (Boolean) Determines if approval is required for elevated access
 - `duration` (Number) The maximum elevated access request duration in hours.
+- `ous` (Attributes Set) A list of AWS OUs the eligibility will apply to. (see [below for nested schema](#nestedatt--ous))
 - `permissions` (Attributes Set) A list of AWS permission sets for the eligibility policy. (see [below for nested schema](#nestedatt--permissions))
 - `user_id` (String) Id of the AWS iam identity center user the eligibility policy will be applied to.
 - `user_name` (String) Name of the AWS iam identity center user the eligibility policy will be applied to.
 
 ### Optional
 
-- `accounts` (Attributes Set) A list of AWS accounts the eligibility will apply to. (see [below for nested schema](#nestedatt--accounts))
-- `ous` (Attributes Set) A list of AWS OUs the eligibility will apply to. (see [below for nested schema](#nestedatt--ous))
 - `ticket_no` (String) The Change Management system ticket system number.
 
 ### Read-Only
@@ -62,15 +62,6 @@ resource "awsteam_eligibility_user" "example" {
 - `id` (String) The UUID of the eligibility.
 - `modified_by` (String) The user to last modify the item
 - `updated_at` (String) The date and time of the last time the item was updated
-
-<a id="nestedatt--permissions"></a>
-### Nested Schema for `permissions`
-
-Required:
-
-- `permission_arn` (String) The ARN of the permission for the eligibility policy. This needs to match the ARN of the name provided in name.
-- `permission_name` (String) Name of the permission for the eligibility policy. This needs to match the name of the ARN provided in ARN.
-
 
 <a id="nestedatt--accounts"></a>
 ### Nested Schema for `accounts`
@@ -88,6 +79,15 @@ Required:
 
 - `ou_id` (String) Id of the OU the eligibility policy will be applied to. This needs to match the id of the name provided in ou_name.
 - `ou_name` (String) Name of the OU the eligibility policy will be applied to. This needs to match the name of the id provided in ou_id.
+
+
+<a id="nestedatt--permissions"></a>
+### Nested Schema for `permissions`
+
+Required:
+
+- `permission_arn` (String) The ARN of the permission for the eligibility policy. This needs to match the ARN of the name provided in name.
+- `permission_name` (String) Name of the permission for the eligibility policy. This needs to match the name of the ARN provided in ARN.
 
 ## Import
 

--- a/docs/resources/eligibility_user.md
+++ b/docs/resources/eligibility_user.md
@@ -15,6 +15,7 @@ Allows configuration of eligibility policies for an aws iam identity center user
 ```terraform
 resource "awsteam_eligibility_user" "example" {
   user_name         = "my-user@contoso.com"
+  user_id           = "d78686b5-bb78-471c-8b2f-817e70e3158b"
   approval_required = true
   duration          = 5
   accounts = [
@@ -46,6 +47,7 @@ resource "awsteam_eligibility_user" "example" {
 - `approval_required` (Boolean) Determines if approval is required for elevated access
 - `duration` (Number) The maximum elevated access request duration in hours.
 - `permissions` (Attributes Set) A list of AWS permission sets for the eligibility policy. (see [below for nested schema](#nestedatt--permissions))
+- `user_id` (String) Id of the AWS iam identity center user the eligibility policy will be applied to.
 - `user_name` (String) Name of the AWS iam identity center user the eligibility policy will be applied to.
 
 ### Optional

--- a/examples/resources/awsteam_eligibility_group/resource.tf
+++ b/examples/resources/awsteam_eligibility_group/resource.tf
@@ -1,5 +1,6 @@
 resource "awsteam_eligibility_group" "example" {
   group_name        = "my-group@contoso.com"
+  group_id          = "d78686b5-bb78-471c-8b2f-817e70e3158b"
   approval_required = true
   duration          = 5
   accounts = [

--- a/examples/resources/awsteam_eligibility_user/resource.tf
+++ b/examples/resources/awsteam_eligibility_user/resource.tf
@@ -1,5 +1,6 @@
 resource "awsteam_eligibility_user" "example" {
   user_name         = "my-user@contoso.com"
+  user_id           = "d78686b5-bb78-471c-8b2f-817e70e3158b"
   approval_required = true
   duration          = 5
   accounts = [

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1,8 +1,13 @@
 package acctest
 
 import (
+	"context"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/brittandeyoung/terraform-provider-awsteam/internal/envvar"
+	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
 )
 
 // These two functions come form the terraform-provider-aws code
@@ -29,4 +34,22 @@ func RunSerialTests2Levels(t *testing.T, testCases map[string]map[string]func(t 
 			RunSerialTests1Level(t, m, d)
 		})
 	}
+}
+
+func NewAWSTeamClient(ctx context.Context) *awsteam.Client {
+	clientId := os.Getenv(envvar.AWSTEAMClientId)
+	clientSecret := os.Getenv(envvar.AWSTEAMClientSecret)
+	graphEndpoint := os.Getenv(envvar.AWSTEAMGraphEndpoint)
+	TokenEndpoint := os.Getenv(envvar.AWSTEAMTokenEndpoint)
+
+	config := &awsteam.Config{
+		ClientId:      clientId,
+		ClientSecret:  clientSecret,
+		GraphEndpoint: graphEndpoint,
+		TokenEndpoint: TokenEndpoint,
+	}
+
+	config.Build(ctx)
+
+	return config.NewClient(ctx)
 }

--- a/internal/provider/approvers_account.go
+++ b/internal/provider/approvers_account.go
@@ -175,12 +175,14 @@ func (r *ApproversAccountResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	if out == nil {
-		resp.Diagnostics.AddError("Create Error", "Received empty Approvers.")
+		resp.Diagnostics.AddWarning("Read Error", "Received empty Approvers. Removing from state.")
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
 	if out.Approvers == nil {
-		resp.Diagnostics.AddError("Create Error", "Received empty Approvers.")
+		resp.Diagnostics.AddWarning("Read Error", "Received empty Approvers. Removing from state.")
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/approvers_ou.go
+++ b/internal/provider/approvers_ou.go
@@ -215,12 +215,14 @@ func (r *ApproversOUResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	if out == nil {
-		resp.Diagnostics.AddError("Read Error", "Received empty Approvers.")
+		resp.Diagnostics.AddWarning("Read Error", "Received empty Approvers. Removing from state.")
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
 	if out.Approvers == nil {
-		resp.Diagnostics.AddError("Read Error", "Received empty Approvers.")
+		resp.Diagnostics.AddWarning("Read Error", "Received empty Approvers. Removing from state.")
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/eligibility.go
+++ b/internal/provider/eligibility.go
@@ -182,12 +182,12 @@ func expandEligibilityPermissions(raw []*EligibilityPermission) []*awsteam.Eligi
 func flattenEligibilityAccounts(apiObject []*awsteam.EligibilityAccount) (types.Set, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	elemType := types.ObjectType{AttrTypes: eligibilityAccountAttrTypes}
+	elems := []attr.Value{}
 
 	if len(apiObject) == 0 {
-		return types.SetValueMust(elemType, []attr.Value{}), diags
+		return types.SetNull(elemType), diags
 	}
 
-	elems := []attr.Value{}
 	for _, account := range apiObject {
 		obj := map[string]attr.Value{
 			"account_id":   types.StringPointerValue(account.Id),
@@ -207,12 +207,12 @@ func flattenEligibilityAccounts(apiObject []*awsteam.EligibilityAccount) (types.
 func flattenEligibilityOUs(apiObject []*awsteam.EligibilityOU) (types.Set, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	elemType := types.ObjectType{AttrTypes: eligibilityOUAttrTypes}
+	elems := []attr.Value{}
 
 	if len(apiObject) == 0 {
-		return types.SetValueMust(elemType, []attr.Value{}), diags
+		return types.SetNull(elemType), diags
 	}
 
-	elems := []attr.Value{}
 	for _, ou := range apiObject {
 		obj := map[string]attr.Value{
 			"ou_id":   types.StringPointerValue(ou.Id),

--- a/internal/provider/eligibility.go
+++ b/internal/provider/eligibility.go
@@ -44,7 +44,7 @@ type EligibilityPermission struct {
 func AccountAttributeSet() schema.SetNestedAttribute {
 	return schema.SetNestedAttribute{
 		MarkdownDescription: "A list of AWS accounts the eligibility will apply to.",
-		Optional:            true,
+		Required:            true,
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: map[string]schema.Attribute{
 				"account_id": schema.StringAttribute{
@@ -75,7 +75,7 @@ func AccountAttributeSet() schema.SetNestedAttribute {
 func OUAttributeSet() schema.SetNestedAttribute {
 	return schema.SetNestedAttribute{
 		MarkdownDescription: "A list of AWS OUs the eligibility will apply to.",
-		Optional:            true,
+		Required:            true,
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: map[string]schema.Attribute{
 				"ou_id": schema.StringAttribute{
@@ -185,7 +185,7 @@ func flattenEligibilityAccounts(apiObject []*awsteam.EligibilityAccount) (types.
 	elems := []attr.Value{}
 
 	if len(apiObject) == 0 {
-		return types.SetNull(elemType), diags
+		return types.SetValueMust(elemType, []attr.Value{}), diags
 	}
 
 	for _, account := range apiObject {
@@ -210,7 +210,7 @@ func flattenEligibilityOUs(apiObject []*awsteam.EligibilityOU) (types.Set, diag.
 	elems := []attr.Value{}
 
 	if len(apiObject) == 0 {
-		return types.SetNull(elemType), diags
+		return types.SetValueMust(elemType, []attr.Value{}), diags
 	}
 
 	for _, ou := range apiObject {

--- a/internal/provider/eligibility_group_test.go
+++ b/internal/provider/eligibility_group_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -9,9 +10,12 @@ import (
 )
 
 func TestAccEligibilityGroupResource_basic(t *testing.T) {
+	ctx := context.Background()
 	resourceName := "awsteam_eligibility_group.test"
-	user1 := gofakeit.Email()
-	user2 := gofakeit.Email()
+	group1 := gofakeit.Email()
+	group2 := gofakeit.Email()
+	groupId1 := gofakeit.UUID()
+	groupId2 := gofakeit.UUID()
 	approval1 := true
 	approval2 := false
 	duration := fmt.Sprint(gofakeit.Number(1, 10))
@@ -28,10 +32,12 @@ func TestAccEligibilityGroupResource_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEligibilityGroupResourceConfig(user1, approval1, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName),
+				Config: testAccEligibilityGroupResourceConfig(group1, groupId1, approval1, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "group_name", user1),
+					testAccEligibilityResourceExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "id", groupId1),
+					resource.TestCheckResourceAttr(resourceName, "group_id", groupId1),
+					resource.TestCheckResourceAttr(resourceName, "group_name", group1),
 					resource.TestCheckResourceAttr(resourceName, "approval_required", fmt.Sprint(approval1)),
 					resource.TestCheckResourceAttr(resourceName, "duration", duration),
 					resource.TestCheckResourceAttr(resourceName, "ticket_no", ticketNo),
@@ -60,9 +66,9 @@ func TestAccEligibilityGroupResource_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEligibilityGroupResourceConfig(user2, approval2, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName),
+				Config: testAccEligibilityGroupResourceConfig(group2, groupId2, approval2, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "group_name", user2),
+					resource.TestCheckResourceAttr(resourceName, "group_name", group2),
 					resource.TestCheckResourceAttr(resourceName, "approval_required", fmt.Sprint(approval2)),
 				),
 			},
@@ -70,10 +76,42 @@ func TestAccEligibilityGroupResource_basic(t *testing.T) {
 	})
 }
 
-func testAccEligibilityGroupResourceConfig(user string, approvalRequired bool, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName string) string {
+func TestAccEligibilityGroupResource_disappears(t *testing.T) {
+	ctx := context.Background()
+	resourceName := "awsteam_eligibility_group.test"
+	group1 := gofakeit.Email()
+	groupId := gofakeit.UUID()
+	approval1 := true
+	duration := fmt.Sprint(gofakeit.Number(1, 10))
+	ticketNo := gofakeit.BS()
+	accountId := gofakeit.DigitN(12)
+	accountName := gofakeit.BS()
+	ouId := "ou-cxt3-2782ty5g" // hard coded fake ou id
+	ouName := gofakeit.BS()
+	permissionArn := "arn:aws:sso:::permissionSet/ssoins-4334d1f197f50907/ps-f5ge203d3d2428d3" // hard coded fake arn
+	permissionName := "elevated"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEligibilityGroupResourceConfig(group1, groupId, approval1, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccEligibilityResourceExists(ctx, resourceName),
+					testAccEligibilityResourceDisappears(ctx, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccEligibilityGroupResourceConfig(group string, groupId string, approvalRequired bool, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName string) string {
 	return fmt.Sprintf(`
 resource "awsteam_eligibility_group" "test" {
 	group_name         = "%s"
+	group_id = "%s"
 	approval_required = %t
 	duration          = %s
 	ticket_no = "%s"
@@ -95,5 +133,5 @@ resource "awsteam_eligibility_group" "test" {
 		permission_name = "%s"
 		}
 	]
-}`, user, approvalRequired, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName)
+}`, group, groupId, approvalRequired, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName)
 }

--- a/internal/provider/eligibility_group_test.go
+++ b/internal/provider/eligibility_group_test.go
@@ -103,7 +103,6 @@ func TestAccEligibilityGroupResource_Accounts(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "approval_required", fmt.Sprint(approval1)),
 					resource.TestCheckResourceAttr(resourceName, "duration", duration),
 					resource.TestCheckResourceAttr(resourceName, "ticket_no", ticketNo),
-					resource.TestCheckNoResourceAttr(resourceName, "accounts"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ous.*",
 						map[string]string{
 							"ou_id":   ouId,
@@ -195,6 +194,7 @@ resource "awsteam_eligibility_group" "test" {
 	approval_required = %t
 	duration          = %s
 	ticket_no = "%s"
+	accounts = []
 	ous = [
 		{
 		ou_id   = "%s"

--- a/internal/provider/eligibility_group_test.go
+++ b/internal/provider/eligibility_group_test.go
@@ -76,6 +76,57 @@ func TestAccEligibilityGroupResource_basic(t *testing.T) {
 	})
 }
 
+func TestAccEligibilityGroupResource_Accounts(t *testing.T) {
+	ctx := context.Background()
+	resourceName := "awsteam_eligibility_group.test"
+	group1 := gofakeit.Email()
+	groupId1 := gofakeit.UUID()
+	approval1 := true
+	duration := fmt.Sprint(gofakeit.Number(1, 10))
+	ticketNo := gofakeit.BS()
+	ouId := "ou-cxt3-2782ty5g" // hard coded fake ou id
+	ouName := gofakeit.BS()
+	permissionArn := "arn:aws:sso:::permissionSet/ssoins-4334d1f197f50907/ps-f5ge203d3d2428d3" // hard coded fake arn
+	permissionName := "elevated"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEligibilityGroupResourceConfigNoAccounts(group1, groupId1, approval1, duration, ticketNo, ouId, ouName, permissionArn, permissionName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEligibilityResourceExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "id", groupId1),
+					resource.TestCheckResourceAttr(resourceName, "group_id", groupId1),
+					resource.TestCheckResourceAttr(resourceName, "group_name", group1),
+					resource.TestCheckResourceAttr(resourceName, "approval_required", fmt.Sprint(approval1)),
+					resource.TestCheckResourceAttr(resourceName, "duration", duration),
+					resource.TestCheckResourceAttr(resourceName, "ticket_no", ticketNo),
+					resource.TestCheckNoResourceAttr(resourceName, "accounts"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ous.*",
+						map[string]string{
+							"ou_id":   ouId,
+							"ou_name": ouName,
+						}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "permissions.*",
+						map[string]string{
+							"permission_arn":  permissionArn,
+							"permission_name": permissionName,
+						}),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccEligibilityGroupResource_disappears(t *testing.T) {
 	ctx := context.Background()
 	resourceName := "awsteam_eligibility_group.test"
@@ -134,4 +185,27 @@ resource "awsteam_eligibility_group" "test" {
 		}
 	]
 }`, group, groupId, approvalRequired, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName)
+}
+
+func testAccEligibilityGroupResourceConfigNoAccounts(group string, groupId string, approvalRequired bool, duration, ticketNo, ouId, ouName, permissionArn, permissionName string) string {
+	return fmt.Sprintf(`
+resource "awsteam_eligibility_group" "test" {
+	group_name         = "%s"
+	group_id = "%s"
+	approval_required = %t
+	duration          = %s
+	ticket_no = "%s"
+	ous = [
+		{
+		ou_id   = "%s"
+		ou_name = "%s"
+		}
+	]
+	permissions = [
+		{
+		permission_arn   = "%s"
+		permission_name = "%s"
+		}
+	]
+}`, group, groupId, approvalRequired, duration, ticketNo, ouId, ouName, permissionArn, permissionName)
 }

--- a/internal/provider/eligibility_test.go
+++ b/internal/provider/eligibility_test.go
@@ -1,0 +1,64 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/brittandeyoung/terraform-provider-awsteam/internal/acctest"
+	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccEligibilityResourceExists(ctx context.Context, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource (%s) ID not set", resourceName)
+		}
+
+		client := acctest.NewAWSTeamClient(ctx)
+		out, err := client.GetEligibility(ctx, &awsteam.GetEligibilityInput{Id: ptr.String(rs.Primary.ID)})
+
+		if err != nil {
+			return err
+		}
+
+		if out == nil {
+			return fmt.Errorf("Eligibility %q does not exist", rs.Primary.ID)
+		}
+
+		if out.Eligibility == nil {
+			return fmt.Errorf("Eligibility %q does not exist", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccEligibilityResourceDisappears(ctx context.Context, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource (%s) ID not set", resourceName)
+		}
+
+		client := acctest.NewAWSTeamClient(ctx)
+		_, err := client.DeleteEligibility(ctx, &awsteam.DeleteEligibilityInput{Id: ptr.String(rs.Primary.ID)})
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/internal/provider/eligibility_user_test.go
+++ b/internal/provider/eligibility_user_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -9,9 +10,12 @@ import (
 )
 
 func TestAccEligibilityUserResource_basic(t *testing.T) {
+	ctx := context.Background()
 	resourceName := "awsteam_eligibility_user.test"
 	user1 := gofakeit.Email()
 	user2 := gofakeit.Email()
+	userId1 := gofakeit.UUID()
+	userId2 := gofakeit.UUID()
 	approval1 := true
 	approval2 := false
 	duration := fmt.Sprint(gofakeit.Number(1, 10))
@@ -28,9 +32,11 @@ func TestAccEligibilityUserResource_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEligibilityUserResourceConfig(user1, approval1, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName),
+				Config: testAccEligibilityUserResourceConfig(user1, userId1, approval1, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					testAccEligibilityResourceExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "id", userId1),
+					resource.TestCheckResourceAttr(resourceName, "user_id", userId1),
 					resource.TestCheckResourceAttr(resourceName, "user_name", user1),
 					resource.TestCheckResourceAttr(resourceName, "approval_required", fmt.Sprint(approval1)),
 					resource.TestCheckResourceAttr(resourceName, "duration", duration),
@@ -61,8 +67,9 @@ func TestAccEligibilityUserResource_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEligibilityUserResourceConfig(user2, approval2, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName),
+				Config: testAccEligibilityUserResourceConfig(user2, userId2, approval2, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", userId2),
 					resource.TestCheckResourceAttr(resourceName, "user_name", user2),
 					resource.TestCheckResourceAttr(resourceName, "approval_required", fmt.Sprint(approval2)),
 				),
@@ -71,10 +78,42 @@ func TestAccEligibilityUserResource_basic(t *testing.T) {
 	})
 }
 
-func testAccEligibilityUserResourceConfig(user string, approvalRequired bool, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName string) string {
+func TestAccEligibilityUserResource_disappears(t *testing.T) {
+	ctx := context.Background()
+	resourceName := "awsteam_eligibility_user.test"
+	user1 := gofakeit.Email()
+	userId1 := gofakeit.UUID()
+	approval1 := true
+	duration := fmt.Sprint(gofakeit.Number(1, 10))
+	ticketNo := gofakeit.BS()
+	accountId := gofakeit.DigitN(12)
+	accountName := gofakeit.BS()
+	ouId := "ou-cxt3-2782ty5g" // hard coded fake ou id
+	ouName := gofakeit.BS()
+	permissionArn := "arn:aws:sso:::permissionSet/ssoins-4334d1f197f50907/ps-f5ge203d3d2428d3" // hard coded fake arn
+	permissionName := "elevated"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEligibilityUserResourceConfig(user1, userId1, approval1, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccEligibilityResourceExists(ctx, resourceName),
+					testAccEligibilityResourceDisappears(ctx, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccEligibilityUserResourceConfig(user string, userId string, approvalRequired bool, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName string) string {
 	return fmt.Sprintf(`
 resource "awsteam_eligibility_user" "test" {
 	user_name         = "%s"
+	user_id = "%s"
 	approval_required = %t
 	duration          = %s
 	ticket_no = "%s"
@@ -96,5 +135,5 @@ resource "awsteam_eligibility_user" "test" {
 		permission_name = "%s"
 		}
 	]
-}`, user, approvalRequired, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName)
+}`, user, userId, approvalRequired, duration, ticketNo, accountId, accountName, ouId, ouName, permissionArn, permissionName)
 }

--- a/internal/provider/settings.go
+++ b/internal/provider/settings.go
@@ -240,12 +240,14 @@ func (r *SettingsResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	if out == nil {
-		resp.Diagnostics.AddError("Read Error", "Received empty Settings.")
+		resp.Diagnostics.AddWarning("Read Error", "Received empty Settings. Removing from state.")
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
 	if out.Settings == nil {
-		resp.Diagnostics.AddError("Read Error", "Received empty Settings.")
+		resp.Diagnostics.AddWarning("Read Error", "Received empty Settings. Removing from state.")
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/sdk/awsteam/api_op_CreateEligibility.go
+++ b/internal/sdk/awsteam/api_op_CreateEligibility.go
@@ -30,6 +30,14 @@ func (client *Client) CreateEligibility(ctx context.Context, in *CreateEligibili
 		return nil, errors.New("Id is required to create Eligibility.")
 	}
 
+	if in.Accounts == nil {
+		in.Accounts = []*EligibilityAccount{}
+	}
+
+	if in.OUs == nil {
+		in.OUs = []*EligibilityOU{}
+	}
+
 	variables := map[string]interface{}{
 		"input": *in,
 	}

--- a/internal/sdk/awsteam/api_op_UpdateEligibility.go
+++ b/internal/sdk/awsteam/api_op_UpdateEligibility.go
@@ -30,6 +30,14 @@ func (client *Client) UpdateEligibility(ctx context.Context, in *UpdateEligibili
 		return nil, errors.New("Id is required to update Eligibility.")
 	}
 
+	if in.Accounts == nil {
+		in.Accounts = []*EligibilityAccount{}
+	}
+
+	if in.OUs == nil {
+		in.OUs = []*EligibilityOU{}
+	}
+
 	variables := map[string]interface{}{
 		"input": *in,
 	}


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR implements the following changes:
1. Adds the `group_id` and `account_id` fields to the eligibility resources. These fields will be used for the resources `id`.
2. Prevents errors when deleting `eligibilities` or `approvers` outside of terraform. 
3. Provides and empty list on `create` or `update` of `eligibilities` when `accounts` or `ous` are not provided. 


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33
Closes #31
Closes #30 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Running Acceptance Tests
<!--
Output from Acceptance tests to test the new feature or fix.
-->

```
$  make testacc
 make testacc                                        
TF_ACC=1 go test ./... -v "-run=TestAcc" -timeout 120m
?       github.com/brittandeyoung/terraform-provider-awsteam    [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/acctest   [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/envvar    [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/names     [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam       [no test files]
=== RUN   TestAccApproversAccountResource_basic
--- PASS: TestAccApproversAccountResource_basic (7.29s)
=== RUN   TestAccApproversAccountResource_accountId
--- PASS: TestAccApproversAccountResource_accountId (4.98s)
=== RUN   TestAccApproversOUResource_basic
--- PASS: TestAccApproversOUResource_basic (6.67s)
=== RUN   TestAccEligibilityGroupResource_basic
--- PASS: TestAccEligibilityGroupResource_basic (4.33s)
=== RUN   TestAccEligibilityGroupResource_Accounts
--- PASS: TestAccEligibilityGroupResource_Accounts (2.22s)
=== RUN   TestAccEligibilityGroupResource_disappears
--- PASS: TestAccEligibilityGroupResource_disappears (2.16s)
=== RUN   TestAccEligibilityUserResource_basic
--- PASS: TestAccEligibilityUserResource_basic (4.03s)
=== RUN   TestAccEligibilityUserResource_disappears
--- PASS: TestAccEligibilityUserResource_disappears (2.33s)
=== RUN   TestAccSettings_serial
=== PAUSE TestAccSettings_serial
=== CONT  TestAccSettings_serial
    settings_test.go:23: Skipping Settings Tests, Environment variable AWSTEAM_RUN_SETTINGS_TESTS is not set to true
--- SKIP: TestAccSettings_serial (0.00s)
PASS
ok      github.com/brittandeyoung/terraform-provider-awsteam/internal/provider  34.445s
...
```