### PR TITLE
Bugfix: Resolve `awsteam_settings` update flow. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,23 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ---
 
 ### New
-* DataSource: `awsteam_accounts` [#44](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/44)
 
 ### Changes
 
 ### Fixes
 
 ### Breaks
+
+
+## 1.1.0 - (2024-03-26)
+---
+
+### New
+* DataSource: `awsteam_accounts` [#44](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/44)
+
+
+### Fixes
+* Resource: `awsteam_settings` - resolved update flow failing to set computed values [#41](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/41)
 
 
 ## 1.0.1 - (2024-03-05)

--- a/internal/provider/settings.go
+++ b/internal/provider/settings.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/brittandeyoung/terraform-provider-awsteam/internal/names"
 	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
@@ -278,36 +279,27 @@ func (r *SettingsResource) Update(ctx context.Context, req resource.UpdateReques
 
 	updateRequired := false
 
-	in := &awsteam.UpdateSettingsInput{
-		TeamAdminGroup:            plan.TeamAdminGroup.ValueStringPointer(),
-		TeamAuditorGroup:          plan.TeamAuditorGroup.ValueStringPointer(),
-		Approval:                  plan.Approval.ValueBoolPointer(),
-		Comments:                  plan.Comments.ValueBoolPointer(),
-		SesNotificationsEnabled:   plan.SesNotificationsEnabled.ValueBoolPointer(),
-		SnsNotificationsEnabled:   plan.SnsNotificationsEnabled.ValueBoolPointer(),
-		SlackNotificationsEnabled: plan.SlackNotificationsEnabled.ValueBoolPointer(),
-		TicketNo:                  plan.TicketNo.ValueBoolPointer(),
-		Duration:                  plan.Duration.ValueInt64Pointer(),
-		Expiry:                    plan.Expiry.ValueInt64Pointer(),
-		ModifiedBy:                plan.ModifiedBy.ValueStringPointer(),
-	}
-
-	if !plan.SesSourceArn.IsUnknown() && !state.SesSourceArn.Equal(plan.SesSourceArn) {
+	if !reflect.DeepEqual(state, plan) {
 		updateRequired = true
-		in.SesSourceArn = plan.SesSourceArn.ValueStringPointer()
-	}
-
-	if !plan.SesSourceEmail.IsUnknown() && !state.SesSourceEmail.Equal(plan.SesSourceEmail) {
-		updateRequired = true
-		in.SesSourceEmail = plan.SesSourceEmail.ValueStringPointer()
-	}
-
-	if !plan.SlackToken.IsUnknown() && !state.SlackToken.Equal(plan.SlackToken) {
-		updateRequired = true
-		in.SlackToken = plan.SlackToken.ValueStringPointer()
 	}
 
 	if updateRequired {
+		in := &awsteam.UpdateSettingsInput{
+			TeamAdminGroup:            plan.TeamAdminGroup.ValueStringPointer(),
+			TeamAuditorGroup:          plan.TeamAuditorGroup.ValueStringPointer(),
+			Approval:                  plan.Approval.ValueBoolPointer(),
+			Comments:                  plan.Comments.ValueBoolPointer(),
+			SesNotificationsEnabled:   plan.SesNotificationsEnabled.ValueBoolPointer(),
+			SnsNotificationsEnabled:   plan.SnsNotificationsEnabled.ValueBoolPointer(),
+			SlackNotificationsEnabled: plan.SlackNotificationsEnabled.ValueBoolPointer(),
+			TicketNo:                  plan.TicketNo.ValueBoolPointer(),
+			Duration:                  plan.Duration.ValueInt64Pointer(),
+			Expiry:                    plan.Expiry.ValueInt64Pointer(),
+			ModifiedBy:                plan.ModifiedBy.ValueStringPointer(),
+			SesSourceArn:              plan.SesSourceArn.ValueStringPointer(),
+			SesSourceEmail:            plan.SesSourceEmail.ValueStringPointer(),
+			SlackToken:                plan.SlackToken.ValueStringPointer(),
+		}
 
 		out, err := r.client.UpdateSettings(ctx, in)
 

--- a/internal/provider/settings_test.go
+++ b/internal/provider/settings_test.go
@@ -25,7 +25,8 @@ func TestAccSettings_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"Resource": {
-			"basic": testAccSettingsResource_basic,
+			"basic":    testAccSettingsResource_basic,
+			"duration": testAccSettingsResource_duration,
 		},
 		"DataSource": {
 			"basic": testAccSettingsDataSource_basic,
@@ -73,6 +74,43 @@ func testAccSettingsResource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "team_admin_group", teamAdminGroup2),
 					resource.TestCheckResourceAttr(resourceName, "team_auditor_group", teamAuditorGroup2)),
+			},
+		},
+	})
+}
+
+func testAccSettingsResource_duration(t *testing.T) {
+	resourceName := "awsteam_settings.test"
+	teamAdminGroup := "Team-Admin-Group"
+	teamAuditorGroup := "Team-Auditor-Group"
+	duration := rand.Intn(10)
+	duration2 := rand.Intn(10)
+	expiry := rand.Intn(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSettingsResourceConfig(teamAdminGroup, teamAuditorGroup, duration, expiry),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "duration", fmt.Sprint(duration)),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccSettingsResourceConfig(teamAdminGroup, teamAuditorGroup, duration2, expiry),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "duration", fmt.Sprint(duration2)),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR resolves the issue where computed fields where not being properly saved to state after an update is performed. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Running Acceptance Tests
<!--
Output from Acceptance tests to test the new feature or fix.
-->

Failing tests before change: 
```
$  make testacc TESTARGS='-run=TestAccSettings'
TF_ACC=1 go test ./... -v -run=TestAccSettings -timeout 120m
?       github.com/brittandeyoung/terraform-provider-awsteam    [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/acctest   [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/envvar    [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/names     [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam       [no test files]
=== RUN   TestAccSettings_serial
=== PAUSE TestAccSettings_serial
=== CONT  TestAccSettings_serial
=== RUN   TestAccSettings_serial/Resource
=== RUN   TestAccSettings_serial/Resource/basic
=== RUN   TestAccSettings_serial/Resource/duration
    settings_test.go:90: Step 3/3 error: Error running apply: exit status 1
        
        Error: Provider returned invalid result object after apply
        
        After the apply operation, the provider still indicated an unknown value for
        awsteam_settings.test.created_at. All values must be known after apply, so
        this is always a bug in the provider and should be reported in the provider's
        own repository. Terraform will still save the other known object values in
        the state.
        
        Error: Provider returned invalid result object after apply
        
        After the apply operation, the provider still indicated an unknown value for
        awsteam_settings.test.modified_by. All values must be known after apply, so
        this is always a bug in the provider and should be reported in the provider's
        own repository. Terraform will still save the other known object values in
        the state.
        
        Error: Provider returned invalid result object after apply
        
        After the apply operation, the provider still indicated an unknown value for
        awsteam_settings.test.updated_at. All values must be known after apply, so
        this is always a bug in the provider and should be reported in the provider's
        own repository. Terraform will still save the other known object values in
        the state.
=== RUN   TestAccSettings_serial/DataSource
=== RUN   TestAccSettings_serial/DataSource/basic
--- FAIL: TestAccSettings_serial (16.54s)
    --- FAIL: TestAccSettings_serial/Resource (11.03s)
        --- PASS: TestAccSettings_serial/Resource/basic (5.08s)
        --- FAIL: TestAccSettings_serial/Resource/duration (5.94s)
    --- PASS: TestAccSettings_serial/DataSource (5.51s)
        --- PASS: TestAccSettings_serial/DataSource/basic (5.51s)
FAIL
FAIL    github.com/brittandeyoung/terraform-provider-awsteam/internal/provider  16.992s
FAIL
make: *** [testacc] Error 1

...
```

Passing tests after change:
```
 ✗ make testacc TESTARGS='-run=TestAccSettings'
TF_ACC=1 go test ./... -v -run=TestAccSettings -timeout 120m
?       github.com/brittandeyoung/terraform-provider-awsteam    [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/acctest   [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/envvar    [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/names     [no test files]
?       github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam       [no test files]
=== RUN   TestAccSettings_serial
=== PAUSE TestAccSettings_serial
=== CONT  TestAccSettings_serial
=== RUN   TestAccSettings_serial/Resource
=== RUN   TestAccSettings_serial/Resource/basic
=== RUN   TestAccSettings_serial/Resource/duration
=== RUN   TestAccSettings_serial/DataSource
=== RUN   TestAccSettings_serial/DataSource/basic
--- PASS: TestAccSettings_serial (12.40s)
    --- PASS: TestAccSettings_serial/Resource (9.28s)
        --- PASS: TestAccSettings_serial/Resource/basic (4.76s)
        --- PASS: TestAccSettings_serial/Resource/duration (4.53s)
    --- PASS: TestAccSettings_serial/DataSource (3.12s)
        --- PASS: TestAccSettings_serial/DataSource/basic (3.12s)
PASS
ok      github.com/brittandeyoung/terraform-provider-awsteam/internal/provider  12.907s
```
